### PR TITLE
Fix check for absolute path

### DIFF
--- a/src/Dflydev/EmbeddedComposer/Core/EmbeddedComposerBuilder.php
+++ b/src/Dflydev/EmbeddedComposer/Core/EmbeddedComposerBuilder.php
@@ -112,7 +112,7 @@ class EmbeddedComposerBuilder
 
         $pristineExternalComposerFilename = $externalComposerFilename;
 
-        if (0 !== strpos($externalComposerFilename, '/')) {
+        if (0 === strspn($externalComposerFilename, '\//') && 1 !== strpos($externalComposerFilename, ':')) {
             $externalComposerFilename = $this->externalRootDirectory.'/'.$externalComposerFilename;
         }
 
@@ -161,7 +161,7 @@ class EmbeddedComposerBuilder
             $externalVendorDirectory = $externalComposerConfig->get('vendor-dir');
         }
 
-        if (0 !== strpos($externalVendorDirectory, '/')) {
+        if (0 === strspn($externalVendorDirectory, '\//') && 1 !== strpos($externalVendorDirectory, ':')) {
             $externalVendorDirectory = $this->externalRootDirectory.'/'.$externalVendorDirectory;
         }
 


### PR DESCRIPTION
This is not as advanced as used by [the Symfony Filesystem component](https://github.com/symfony/Filesystem/blob/master/Filesystem.php#L432-L448), but at last it supports more paths (like Windows paths).

Before this PR, the paths resulted in `C:\Users\wouter\Documents\sculpin\C:\Users\wouter\Documents\sculpin\composer.json`, which is invalid of course.

I wonder if we actually need to do this, as `->get('vendor-dir')` always returns an absolute path in Composer?
