### PR TITLE
Removed call to private loadRepository

### DIFF
--- a/src/Dflydev/EmbeddedComposer/Core/EmbeddedComposer.php
+++ b/src/Dflydev/EmbeddedComposer/Core/EmbeddedComposer.php
@@ -155,10 +155,15 @@ class EmbeddedComposer implements EmbeddedComposerInterface
             $installer->setAdditionalInstalledRepository(
                 $this->internalRepository
             );
+            $pluginManager = $composer->getPluginManager();
 
-            $composer->getPluginManager()->loadRepository(
-                $this->internalRepository
-            );
+            foreach ($this->internalRepository->getPackages() as $package) {
+                if ($package instanceof AliasPackage || 'composer-plugin' !== $package->getType()) {
+                    continue;
+                }
+
+                $pluginManager->registerPackage($package);
+            }
         }
 
         return $installer;


### PR DESCRIPTION
PluginManager#loadRepository [is now private](https://github.com/composer/composer/blob/1.1/src/Composer/Plugin/PluginManager.php#L248).

This PR adapts to this change and uses `registerPackage` directly.