### PR TITLE
Fix the detection of absolute paths on Windows

### DIFF
--- a/src/Dflydev/EmbeddedComposer/Core/EmbeddedComposerBuilder.php
+++ b/src/Dflydev/EmbeddedComposer/Core/EmbeddedComposerBuilder.php
@@ -112,7 +112,7 @@ class EmbeddedComposerBuilder
 
         $pristineExternalComposerFilename = $externalComposerFilename;
 
-        if (0 !== strpos($externalComposerFilename, '/')) {
+        if (0 !== strpos($externalComposerFilename, '/') && 1 !== strpos($externalComposerFilename, ':')) {
             $externalComposerFilename = $this->externalRootDirectory.'/'.$externalComposerFilename;
         }
 
@@ -161,7 +161,7 @@ class EmbeddedComposerBuilder
             $externalVendorDirectory = $externalComposerConfig->get('vendor-dir');
         }
 
-        if (0 !== strpos($externalVendorDirectory, '/')) {
+        if (0 !== strpos($externalVendorDirectory, '/') && 1 !== strpos($externalVendorDirectory, ':')) {
             $externalVendorDirectory = $this->externalRootDirectory.'/'.$externalVendorDirectory;
         }
 


### PR DESCRIPTION
While trying to contribute to the new Doctrine website from my Windows computer, I discovered the Sculpin was incompatible with Windows due to a bug in embedded-composer when detecting absolute paths.

The updated logic is similar to the logic used in Composer itself.